### PR TITLE
Fix workflow Python version

### DIFF
--- a/.github/workflows/crawl-dutch-publicaties.yml
+++ b/.github/workflows/crawl-dutch-publicaties.yml
@@ -15,7 +15,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          # Use a maintained Python version
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ This repo collects recent entries from the Dutch "Lokale Bekendmakingen" (local 
 
 ### Usage
 
-Run locally:
+Run locally with Python 3.10+:
 ```bash
-python scrape.py
+python crawler_officiele.py --max-items 500


### PR DESCRIPTION
## Summary
- update Python version in workflow to 3.11
- fix README example

## Testing
- `python -m py_compile crawler_officiele.py`


------
https://chatgpt.com/codex/tasks/task_e_685c07056a548329884fa62d28fef385