### PR TITLE
Fix workflow and show Python version

### DIFF
--- a/.github/workflows/crawl-dutch-publicaties.yml
+++ b/.github/workflows/crawl-dutch-publicaties.yml
@@ -18,6 +18,9 @@ jobs:
           # Use a maintained Python version
           python-version: '3.11'
 
+      - name: Verify Python version
+        run: python --version
+
       - name: Install dependencies
         run: |
           pip install requests beautifulsoup4 lxml datasets tqdm huggingface_hub

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repo collects recent entries from the Dutch "Lokale Bekendmakingen" (local 
 
 ### Usage
 
-Run locally with Python 3.10+:
+Run locally with Python 3.11+:
 ```bash
 python crawler_officiele.py --max-items 500
+```


### PR DESCRIPTION
## Summary
- add a step in the workflow to print the installed Python version
- keep README instructions for running with Python 3.11+

## Testing
- `python -m py_compile crawler_officiele.py`
- `python crawler_officiele.py --max-items 1 --delay 0.01` *(fails: ModuleNotFoundError)*


------
https://chatgpt.com/codex/tasks/task_e_685c1c338e488329a664ab98c7ea27fa