### PR TITLE
Update docs and workflow

### DIFF
--- a/.github/workflows/crawl-dutch-publicaties.yml
+++ b/.github/workflows/crawl-dutch-publicaties.yml
@@ -1,8 +1,8 @@
-name: Daily Dutch FRBR Crawl
+name: Weekly Dutch FRBR Crawl
 
 on:
   schedule:
-    - cron: '0 3 * * *'   # every day at 03:00 UTC
+    - cron: '0 3 * * 0'   # every Sunday at 03:00 UTC
   workflow_dispatch:     # manual trigger
 
 jobs:
@@ -23,12 +23,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install requests beautifulsoup4 lxml datasets tqdm huggingface_hub
+          pip install -r requirements.txt
 
-      - name: Run crawler
+      - name: Run pipeline
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          HF_DATASET_REPO: vGassen/Dutch-Officiele-Publicaties-Lokale-Bekendmakingen
-          HF_PRIVATE: false
         run: |
-          python crawler_officiele.py --max-items 500 --resume
+          python step1_collect_urls.py
+          python step2_download_items.py
+          python step3_clean_text.py
+          python step4_upload_shards.py --token $HF_TOKEN

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,31 @@
 # Dutch Lokale Bekendmakingen Scraper
 
-This repo collects recent entries from the Dutch "Lokale Bekendmakingen" (local government announcements) and publishes them to the Hugging Face dataset:
+This project collects recent entries from the Dutch "Lokale Bekendmakingen" (local government announcements) and publishes them to the [Hugging Face dataset](https://huggingface.co/datasets/vGassen/Dutch-Lokale-Bekendmakingen).
 
-👉 https://huggingface.co/datasets/vGassen/Dutch-Lokale-Bekendmakingen
-
-### Fields:
-- `URL`: Link to the full document
-- `content`: Scraped text content
-- `source`: Always `"Lokale Bekendmakingen"`
+### Fields
+- `url` – link to the document
+- `content` – cleaned text content
+- `source` – either `officielepublicaties` or `lokalebekendmakingen`
 
 ### Usage
 
-Run locally with Python 3.11+:
-```bash
-python crawler_officiele.py --max-items 500
-```
+Python 3.11+ is recommended. The scraping pipeline consists of four scripts that should be run in order:
+
+1. **Collect URLs**
+   ```bash
+   python step1_collect_urls.py
+   ```
+2. **Download the items**
+   ```bash
+   python step2_download_items.py
+   ```
+3. **Clean text and create JSONL**
+   ```bash
+   python step3_clean_text.py
+   ```
+4. **Upload to the dataset**
+   ```bash
+   python step4_upload_shards.py --token <HF_TOKEN>
+   ```
+
+You can also store the Hugging Face token in a `.env` file using `HF_TOKEN=<token>`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests>=2.32
 beautifulsoup4>=4.12
 lxml>=4.9
 huggingface_hub>=0.23
+python-dotenv>=1.0


### PR DESCRIPTION
## Summary
- document the new 4-step pipeline
- list python-dotenv in requirements
- add MIT license
- update the GitHub workflow to run weekly and run the pipeline scripts

## Testing
- `python -m py_compile step1_collect_urls.py step2_download_items.py step3_clean_text.py step4_upload_shards.py`

------
https://chatgpt.com/codex/tasks/task_e_686142edd28483299bdafda652fd9c29